### PR TITLE
Add MLDSA65 variant to CurveKind enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See [MAINTAINERS.md](./MAINTAINERS.md)
 for instructions to keep up to date.
 
+## Unreleased
+
+* Added `MLDSA65` variant to `CurveKind` enum to support NEAR post-quantum (ML-DSA-65) keys and signatures.
+
 ## [2.5.1]
 
 * Bumped to [firehose-core v1.14.6](https://github.com/streamingfast/firehose-core/releases/tag/v1.14.6).

--- a/pb/sf/near/type/v1/type.pb.go
+++ b/pb/sf/near/type/v1/type.pb.go
@@ -26,6 +26,7 @@ type CurveKind int32
 const (
 	CurveKind_ED25519   CurveKind = 0
 	CurveKind_SECP256K1 CurveKind = 1
+	CurveKind_MLDSA65   CurveKind = 2
 )
 
 // Enum value maps for CurveKind.
@@ -33,10 +34,12 @@ var (
 	CurveKind_name = map[int32]string{
 		0: "ED25519",
 		1: "SECP256K1",
+		2: "MLDSA65",
 	}
 	CurveKind_value = map[string]int32{
 		"ED25519":   0,
 		"SECP256K1": 1,
+		"MLDSA65":   2,
 	}
 )
 
@@ -7381,10 +7384,11 @@ const file_sf_near_type_v1_type_proto_rawDesc = "" +
 	"\vreceiver_id\x18\x02 \x01(\tR\n" +
 	"receiverId\x12!\n" +
 	"\fmethod_names\x18\x03 \x03(\tR\vmethodNames\"\x16\n" +
-	"\x14FullAccessPermission*'\n" +
+	"\x14FullAccessPermission*4\n" +
 	"\tCurveKind\x12\v\n" +
 	"\aED25519\x10\x00\x12\r\n" +
-	"\tSECP256K1\x10\x01*,\n" +
+	"\tSECP256K1\x10\x01\x12\v\n" +
+	"\aMLDSA65\x10\x02*,\n" +
 	"\x11ExecutionMetadata\x12\x17\n" +
 	"\x13ExecutionMetadataV1\x10\x00*\xa9\x01\n" +
 	"\x14FunctionCallErrorSer\x12\x14\n" +

--- a/proto/sf/near/type/v1/type.proto
+++ b/proto/sf/near/type/v1/type.proto
@@ -161,6 +161,7 @@ message CryptoHash {
 enum CurveKind {
   ED25519 = 0;
   SECP256K1 = 1;
+  MLDSA65 = 2;
 }
 
 message Signature {


### PR DESCRIPTION
## Summary

NEAR added post-quantum **ML-DSA-65** keys and signatures. Testnet now carries `MLDSA65` public keys on-chain. Downstream codecs (e.g. `near-firehose-indexer`) cannot encode them without a matching `CurveKind` value and currently panic:

```
not implemented: MLDSA65 public key is not supported yet
```

## Changes

- `proto/sf/near/type/v1/type.proto`: add `MLDSA65 = 2` to `CurveKind` (mirrors nearcore `KeyType::MLDSA65 = 2`).
- Regenerated `pb/sf/near/type/v1/type.pb.go`.
- CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)